### PR TITLE
Use Reader instead of Scanner to avoid large token issue

### DIFF
--- a/chug/chug.go
+++ b/chug/chug.go
@@ -2,6 +2,7 @@ package chug
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -33,9 +34,15 @@ type LogEntry struct {
 }
 
 func Chug(reader io.Reader, out chan<- Entry) {
-	scanner := bufio.NewScanner(reader)
-	for scanner.Scan() {
-		out <- entry(scanner.Bytes())
+	scanner := bufio.NewReader(reader)
+	for {
+		line, err := scanner.ReadBytes('\n')
+		if line != nil {
+			out <- entry(bytes.TrimSuffix(line, []byte{'\n'}))
+		}
+		if err != nil {
+			break
+		}
 	}
 	close(out)
 }


### PR DESCRIPTION
Ran into an issue where `veritas chug` was bailing out when it hit a line with a massive node stack trace error.  Turns out `bufio.Scanner` has a token-size limit that is exceeded (which results in an irrecoverable error).  Switching to a `bufio.Reader` resolves the issue.